### PR TITLE
[Hero] Fix the Fathom event tracking

### DIFF
--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -13,7 +13,7 @@ export const Hero = (props: HeroProps): JSX.Element => {
         <Link href="/what-we-do">
             <a
                 onClick={(_e) => {
-                    trackEvent("what-we-do")
+                    trackEvent("A2PINPR4")
                 }}
             >
                 Read more...


### PR DESCRIPTION
We need to use the goal's ID, rather than its name! 😬