### PR TITLE
[SEO] Add "social media" metatags

### DIFF
--- a/src/components/social-media-meta-tags.tsx
+++ b/src/components/social-media-meta-tags.tsx
@@ -1,0 +1,35 @@
+import React from "react"
+
+// Shared content
+const TITLE = `Textualize.io`
+const DESCRIPTION = `The terminal can be more powerful and beautiful than you ever thought`
+const IMAGE_URL = "https://res.cloudinary.com/textualize-io/image/upload/v1650621291/social%20media%20share%20image.png"
+const SITE_URL = "https://www.textualize.io/"
+// Twitter-specific stuff
+const TWITTER_SITE = "@textualizeio"
+// OpenGraph-specific stuff
+const OPENGRAPH_TYPE = "website"
+
+export function SocialMediaMetaTags(): JSX.Element {
+    // Basically modeled after `view-source:https://github.com/Textualize/rich` ^_^
+
+    return (
+        <>
+            {/* Let's start with Twitter-specific tags...*/}
+            {/* @link https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup */}
+            <meta name="twitter:image:src" content={IMAGE_URL} />
+            <meta name="twitter:site" content={TWITTER_SITE} />
+            <meta name="twitter:card" content="summary_large_image" />
+            <meta name="twitter:title" content={TITLE} />
+            <meta name="twitter:description" content={DESCRIPTION} />
+            {/* And now for the OpenGraph tags...*/}
+            {/* @link https://ogp.me/ */}
+            <meta property="og:image" content={IMAGE_URL} />
+            <meta property="og:image:alt" content={DESCRIPTION} />
+            <meta property="og:type" content={OPENGRAPH_TYPE} />
+            <meta property="og:title" content={TITLE} />
+            <meta property="og:url" content={SITE_URL} />
+            <meta property="og:description" content={DESCRIPTION} />
+        </>
+    )
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -7,8 +7,6 @@ import { initAnalytics } from "../services/frontend/analytics"
 import * as themeServices from "../services/shared/theme"
 import "../style/index.scss"
 
-/* eslint @next/next/no-page-custom-font: "off" */
-
 export default function MyApp({ Component, pageProps }: AppProps) {
     const router = useRouter()
 
@@ -28,10 +26,6 @@ export default function MyApp({ Component, pageProps }: AppProps) {
             <Head>
                 <title>Textualize</title>
                 <meta name="description" content="Because Terminals are here to stay" />
-                <link rel="icon" href="/textualize-logo.svg" />
-                <link rel="preconnect" href="https://fonts.googleapis.com" />
-                <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
-                <link href="https://fonts.googleapis.com/css2?family=Fira+Mono&amp;display=swap" rel="stylesheet" />
             </Head>
 
             <Layout>

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,11 +1,17 @@
+import React from "react"
 import { Head, Html, Main, NextScript } from "next/document"
+import { SocialMediaMetaTags } from "../components/social-media-meta-tags"
 
 export default function Document() {
-    // Just to add `lang="en"`...
     // @link https://nextjs.org/docs/advanced-features/custom-document
     return (
         <Html lang="en">
-            <Head />
+            <Head>
+                <link rel="icon" href="/textualize-logo.svg" />
+                {/* @link https://nextjs.org/docs/basic-features/font-optimization */}
+                <link href="https://fonts.googleapis.com/css2?family=Fira+Mono&amp;display=optional" rel="stylesheet" />
+                <SocialMediaMetaTags />
+            </Head>
             <body>
                 <Main />
                 <NextScript />


### PR DESCRIPTION
Can be tested there: https://cards-dev.twitter.com/validator :slightly_smiling_face: 
With the URL `https://textualize-io-git-add-social-media-meta-tags-textualize.vercel.app/`

closes #18 