### PR TITLE
[projects] Add a shared `ProjectsDataContext`, use it to implement a "video URL placeholders" machinery

### DIFF
--- a/src/components/atomic/video.tsx
+++ b/src/components/atomic/video.tsx
@@ -1,6 +1,8 @@
 import React from "react"
 import fscreen from "fscreen"
 import { useInView } from "react-intersection-observer"
+import { ProjectsDataContext } from "../../contexts/projects-data"
+import { replaceProjectsRelatedPlaceholders } from "../../helpers/placeholder-helpers"
 
 interface VideoProps {
     videoUrl: string
@@ -18,6 +20,8 @@ export const Video = (props: VideoProps): JSX.Element => {
     const videoElementRef = React.useRef<HTMLVideoElement>(null)
 
     const scrollTopBeforeFullscreen = React.useRef<number>(0)
+
+    const projectsData = React.useContext(ProjectsDataContext)
 
     const onFullScreenChange = React.useCallback(() => {
         setVideoIsFullScreen(
@@ -51,9 +55,12 @@ export const Video = (props: VideoProps): JSX.Element => {
         }
     }
 
+    // We can use placeholders such as "PROJECT_VIDEO_URL:textual" in the video URL:
+    const videoUrl = replaceProjectsRelatedPlaceholders(props.videoUrl, projectsData)
+
     const video = (
         <video
-            src={props.videoUrl}
+            src={videoUrl}
             ref={videoElementRef}
             className="video__content"
             autoPlay

--- a/src/contexts/projects-data.ts
+++ b/src/contexts/projects-data.ts
@@ -1,0 +1,4 @@
+import React from "react"
+import type { ProjectData } from "../domain"
+
+export const ProjectsDataContext = React.createContext<ProjectData[]>([])

--- a/src/helpers/common-static-props.ts
+++ b/src/helpers/common-static-props.ts
@@ -1,0 +1,17 @@
+import { GetStaticPropsContext } from "next"
+import type { ProjectData } from "../domain"
+import * as githubBackendServices from "../services/backend/github"
+import * as projectsBackendServices from "../services/backend/projects"
+
+interface CommonStaticProps {
+    projectsData: ProjectData[]
+}
+
+export async function getCommonStaticProps(_context: GetStaticPropsContext): Promise<{ props: CommonStaticProps }> {
+    const projectsData = await projectsBackendServices.projects()
+    await githubBackendServices.attachCurrentStarsCountsToRepositories(projectsData)
+
+    return {
+        props: { projectsData },
+    }
+}

--- a/src/helpers/placeholder-helpers.ts
+++ b/src/helpers/placeholder-helpers.ts
@@ -1,0 +1,21 @@
+import type { ProjectData } from "../domain"
+
+type ProjectRelatedPlaceholderHandler = (_target: string, _projectsData: ProjectData[]) => string
+
+const projectRelatedPlaceholderHandlers: ProjectRelatedPlaceholderHandler[] = [
+    (target: string, projectsData: ProjectData[]): string => {
+        for (const project of projectsData) {
+            // N.B. We should use `replaceAll()` and manage a polyfill for it, but for the moment
+            // we don't need that so let's keep it simple and only replace the 1st occurrence of each placeholder:-)
+            target = target.replace(`[PROJECT_VIDEO_URL:${project.id}]`, project.videoUrl)
+        }
+        return target
+    },
+]
+
+export function replaceProjectsRelatedPlaceholders(target: string, projectsData: ProjectData[]): string {
+    for (const handler of projectRelatedPlaceholderHandlers) {
+        target = handler(target, projectsData)
+    }
+    return target
+}

--- a/src/pages/[projectId]/gallery/[[...gallerySegments]].tsx
+++ b/src/pages/[projectId]/gallery/[[...gallerySegments]].tsx
@@ -3,12 +3,17 @@ import type { GetStaticPaths, GetStaticProps } from "next"
 import Head from "next/head"
 import { GetStaticPropsResult } from "next/types"
 import { GalleryIndex } from "../../../components/page-specific/gallery/gallery-index"
+import { ProjectsDataContext } from "../../../contexts/projects-data"
+import { ProjectData } from "../../../domain"
+import { getCommonStaticProps as commonGetStaticProps } from "../../../helpers/common-static-props"
 import * as githubBackendServices from "../../../services/backend/github"
 import * as galleryProjectsBackendServices from "../../../services/backend/projects-galleries"
-import { ProjectGalleryPageProps } from "../../../services/backend/projects-galleries"
 import * as galleryProjectsSharedServices from "../../../services/shared/projects-galleries"
 
-export default function ProjectGalleryPage(props: galleryProjectsBackendServices.ProjectGalleryPageProps) {
+interface ProjectGalleryPageProps extends galleryProjectsBackendServices.ProjectGalleryPageProps {
+    projectsData: ProjectData[]
+}
+export default function ProjectGalleryPage(props: ProjectGalleryPageProps) {
     const canonicalUrl = galleryProjectsSharedServices.projectGalleryPageUrl(props)
 
     return (
@@ -16,14 +21,16 @@ export default function ProjectGalleryPage(props: galleryProjectsBackendServices
             <Head>
                 <link rel="canonical" href={canonicalUrl} />
             </Head>
-            <GalleryIndex
-                projectId={props.projectId}
-                currentPage={props.page}
-                pagesCount={props.pagesCount}
-                galleryItems={props.galleryItems}
-                selectedCategory={props.category ?? undefined}
-                galleryCategoriesWithCount={props.galleryCategoriesWithCount}
-            />
+            <ProjectsDataContext.Provider value={props.projectsData}>
+                <GalleryIndex
+                    projectId={props.projectId}
+                    currentPage={props.page}
+                    pagesCount={props.pagesCount}
+                    galleryItems={props.galleryItems}
+                    selectedCategory={props.category ?? undefined}
+                    galleryCategoriesWithCount={props.galleryCategoriesWithCount}
+                />
+            </ProjectsDataContext.Provider>
         </>
     )
 }
@@ -66,7 +73,9 @@ export const getStaticProps: GetStaticProps = async (
         }
     }
 
-    return { props }
+    const { props: commonProps } = await commonGetStaticProps(context)
+
+    return { props: { ...commonProps, ...props } }
 }
 
 export const getStaticPaths: GetStaticPaths = async () => {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,9 +3,9 @@ import type { GetStaticProps } from "next"
 import { MailList } from "../components/mail-list"
 import { Hero } from "../components/page-specific/home/hero"
 import { ProjectsIndex } from "../components/page-specific/home/projects-index"
+import { ProjectsDataContext } from "../contexts/projects-data"
 import type { ProjectData } from "../domain"
-import * as githubBackendServices from "../services/backend/github"
-import * as projectsBackendServices from "../services/backend/projects"
+import { getCommonStaticProps as commonGetStaticProps } from "../helpers/common-static-props"
 
 interface HomePageProps {
     projectsData: ProjectData[]
@@ -15,21 +15,22 @@ export default function HomePage(props: HomePageProps) {
     // At the moment the video we display in the "Hero" is the Textual one, but that may change in the future
     return (
         <>
-            <Hero videoUrl={props.projectsData[0].videoUrl} />
-            <MailList />
-            <ProjectsIndex projectsData={props.projectsData} />
+            <ProjectsDataContext.Provider value={props.projectsData}>
+                <Hero videoUrl={props.projectsData[0].videoUrl} />
+                <MailList />
+                <ProjectsIndex projectsData={props.projectsData} />
+            </ProjectsDataContext.Provider>
         </>
     )
 }
 
-export const getStaticProps: GetStaticProps = async (_context) => {
+export const getStaticProps: GetStaticProps = async (context) => {
     // N.B. This is only executed server-side, thanks to the magic of Next.js 👌
     // @link https://nextjs.org/docs/api-reference/data-fetching/get-static-props
-    const projects = await projectsBackendServices.projects()
-    await githubBackendServices.attachCurrentStarsCountsToRepositories(projects)
+    const { props: commonProps } = await commonGetStaticProps(context)
 
     return {
-        props: { projectsData: projects },
+        props: commonProps,
         // Next.js will attempt to re-generate the page:
         // - When a request comes in
         // - At most once every hour

--- a/src/pages/what-we-do.mdx
+++ b/src/pages/what-we-do.mdx
@@ -1,5 +1,10 @@
 import { Callout } from "../components/callout"
 import { Terminal } from "../components/terminal"
+import { ProjectsDataContext } from "../contexts/projects-data"
+
+export { getCommonStaticProps as getStaticProps } from "../helpers/common-static-props"
+
+<ProjectsDataContext.Provider value={props.projectsData}>
 
 <div className="container container--text">
 
@@ -42,7 +47,7 @@ Our answer to this is [Textual](https://github.com/Textualize/textual), an Open-
 
 The following demonstrates a little of what is possible with a Textual TUI. Note the light / dark mode switch a few seconds in.
 
-<Terminal videoUrl="https://d32lig6y1jobn4.cloudfront.net/textual.mp4" />
+<Terminal videoUrl="[PROJECT_VIDEO_URL:textual]" />
 
 ## Textual for Everyone
 
@@ -62,3 +67,5 @@ As excited as we are about this web service, our roots are in the Open-source co
 [survey]: https://github.com/Textualize/terminal-survey
 
 </div>
+
+</ProjectsDataContext.Provider>

--- a/src/services/backend/github.ts
+++ b/src/services/backend/github.ts
@@ -42,8 +42,8 @@ export async function attachCurrentStarsCountsToRepositories(
 
     // ...But we launch them in parallel, with a limited concurrency:
     const throttle = pThrottle({
-        limit: GITHUB_API_CONCURRENT_CALLS_BATCH_SIZE,
-        interval: GITHUB_API_PAUSE_DURATION_AFTER_EACH_BATCH,
+        limit: DONT_FETCH_DATA ? 1000 : GITHUB_API_CONCURRENT_CALLS_BATCH_SIZE,
+        interval: DONT_FETCH_DATA ? 0 : GITHUB_API_PAUSE_DURATION_AFTER_EACH_BATCH,
     })
     const repositoriesStatsThrottledPromiseFactories = repositoriesStatsPromiseFactories.map((promise) =>
         throttle(promise)


### PR DESCRIPTION
Our React components now have access to our "Textualize projects" data through a shared `ProjectsDataContext`.

The first application of this is to implement a "video URL placeholders" machinery, so instead of duplicating the URL of our projects videos in the Markdown files we can now do this:
![Screenshot from 2022-04-27 09-31-22](https://user-images.githubusercontent.com/722388/165476470-e2102543-a353-480e-b6a5-6746520d4400.png)


That's a lot of code for such a small thing :sweat_smile: , but now that the "shared projects data" and "placeholders" structure is here it could be extended to give us other features later on :crossed_fingers: 

closes #32 