### PR TITLE
[backend] Add a "build" cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "scripts": {
         "dev": "next dev",
         "build": "next build",
-        "build:prod": "npm run scripts:transpile && npm run scripts:generate-data-code-for-galleries && next build",
+        "build:prod": "npm run scripts:transpile && npm run scripts:generate-data-code-for-galleries && next build && cat .next/cache/textualize-cache.json",
         "start": "next start",
         "prepare": "husky install",
         "cypress:open": "cypress open",

--- a/src/pages/[projectId]/gallery/[[...gallerySegments]].tsx
+++ b/src/pages/[projectId]/gallery/[[...gallerySegments]].tsx
@@ -49,7 +49,7 @@ export const getStaticProps: GetStaticProps = async (
 
     //TODO: remove this once we're confident enough in this cache implementation :-)
     const buildCacheBackendServices = await import("../../../services/backend/build-cache")
-    buildCacheBackendServices.enableDebugMode()
+    buildCacheBackendServices.enableDebugMode({ miss: true, hit: false, set: true })
 
     const gallerySegments =
         context.params.gallerySegments && Array.isArray(context.params.gallerySegments)

--- a/src/pages/[projectId]/gallery/[[...gallerySegments]].tsx
+++ b/src/pages/[projectId]/gallery/[[...gallerySegments]].tsx
@@ -47,9 +47,9 @@ export const getStaticProps: GetStaticProps = async (
         throw new Error(`Invalid projectId "${projectId}"`)
     }
 
-    //TODO: remove this once we're confident enough in our static pages generation :-)
-    const cacheSharedServices = await import("../../../services/shared/cache")
-    cacheSharedServices.enableDebugMode()
+    //TODO: remove this once we're confident enough in this cache implementation :-)
+    const buildCacheBackendServices = await import("../../../services/backend/build-cache")
+    buildCacheBackendServices.enableDebugMode()
 
     const gallerySegments =
         context.params.gallerySegments && Array.isArray(context.params.gallerySegments)

--- a/src/services/backend/_helpers.ts
+++ b/src/services/backend/_helpers.ts
@@ -1,0 +1,4 @@
+import { join } from "node:path"
+
+export const projectRootPath =
+    process.env["PROJECT_ROOT_PATH"] || join(new URL(import.meta.url).pathname, "..", "..", "..", "..")

--- a/src/services/backend/build-cache.ts
+++ b/src/services/backend/build-cache.ts
@@ -1,0 +1,59 @@
+/**
+ * This is a very simple and naive "across Vercel builds" cache.
+ * Pretty inefficient, as we're constantly reading the whole cache content from a JSON file,
+ * but still better than querying the GitHub API again and again... :-)
+ * We can only store JSON-able data there.
+ *
+ * @link https://vercel.com/docs/concepts/deployments/build-step#caching
+ */
+import { promises as fs } from "node:fs"
+import { join } from "node:path"
+import { projectRootPath } from "./_helpers"
+
+type CacheKey = string
+type CacheContent = Record<CacheKey, any>
+
+const cacheFilePath = join(projectRootPath, ".next", "cache", "textualize-cache.json")
+
+let debugMode: boolean = true
+
+export function enableDebugMode(): void {
+    debugMode = true
+}
+
+export async function get<T = any>(key: CacheKey, defaultValue: T | null = null): Promise<T | null> {
+    const cacheContent = await wholeCacheContent()
+
+    const value = cacheContent[key]
+    if (value === undefined) {
+        debugMode && console.debug(`BuildCache: MISS for key "${key}"`)
+        return defaultValue
+    }
+    debugMode && console.debug(`BuildCache: HIT for key "${key}"`)
+    return value
+}
+
+export async function set<T = any>(key: CacheKey, value: T): Promise<void> {
+    debugMode && console.debug(`BuildCache: saving data for key "${key}"`)
+    const cacheContent = await wholeCacheContent()
+    cacheContent[key] = value
+    await saveWholeCacheContent(cacheContent)
+}
+
+async function wholeCacheContent(): Promise<CacheContent> {
+    try {
+        const cacheContentRaw = await fs.readFile(cacheFilePath, "utf8")
+        return JSON.parse(cacheContentRaw)
+    } catch (err) {
+        return {}
+    }
+}
+
+async function saveWholeCacheContent(cacheContent: CacheContent): Promise<void> {
+    try {
+        const cacheContentRaw = JSON.stringify(cacheContent)
+        await fs.writeFile(cacheFilePath, cacheContentRaw, "utf8")
+    } catch (err) {
+        debugMode && console.warn(`Couldn't save the build cache in "${cacheFilePath}": ${err}`)
+    }
+}

--- a/src/services/backend/build-cache.ts
+++ b/src/services/backend/build-cache.ts
@@ -15,10 +15,10 @@ type CacheContent = Record<CacheKey, any>
 
 const cacheFilePath = join(projectRootPath, ".next", "cache", "textualize-cache.json")
 
-let debugMode: boolean = true
+const debugMode = { miss: false, hit: false, set: false }
 
-export function enableDebugMode(): void {
-    debugMode = true
+export function enableDebugMode(debug: { miss: boolean; hit: boolean; set: boolean }): void {
+    Object.assign(debugMode, debug)
 }
 
 export async function get<T = any>(key: CacheKey, defaultValue: T | null = null): Promise<T | null> {
@@ -26,15 +26,15 @@ export async function get<T = any>(key: CacheKey, defaultValue: T | null = null)
 
     const value = cacheContent[key]
     if (value === undefined) {
-        debugMode && console.debug(`BuildCache: MISS for key "${key}"`)
+        debugMode.miss && console.debug(`BuildCache: MISS for key "${key}"`)
         return defaultValue
     }
-    debugMode && console.debug(`BuildCache: HIT for key "${key}"`)
+    debugMode.hit && console.debug(`BuildCache: HIT for key "${key}"`)
     return value
 }
 
 export async function set<T = any>(key: CacheKey, value: T): Promise<void> {
-    debugMode && console.debug(`BuildCache: saving data for key "${key}"`)
+    debugMode.set && console.debug(`BuildCache: saving data for key "${key}"`)
     const cacheContent = await wholeCacheContent()
     cacheContent[key] = value
     await saveWholeCacheContent(cacheContent)

--- a/src/services/backend/github.ts
+++ b/src/services/backend/github.ts
@@ -1,7 +1,7 @@
 import pThrottle from "p-throttle"
 import type { RepoId } from "../../domain"
 import { humanizeStargazersCount } from "../../helpers/conversion-helpers"
-import * as cacheSharedServices from "../shared/cache"
+import * as buildCacheBackendServices from "../backend/build-cache"
 
 const REPO_URL_REGEX = /^https:\/\/github.com\/(?<owner>[^/]+)\/(?<repo>[^/]+)$/
 const REPO_URL_PATTERN = "https://github.com/{owner}/{repo}"
@@ -12,7 +12,7 @@ const DONT_FETCH_DATA = Boolean(process.env["DONT_FETCH_GITHUB_STARS_DATA"])
 
 const GITHUB_API_CONCURRENT_CALLS_BATCH_SIZE = parseInt(process.env["GITHUB_API_CONCURRENT_CALLS_BATCH_SIZE"] || "2")
 const GITHUB_API_PAUSE_DURATION_AFTER_EACH_BATCH = parseInt(
-    process.env["GITHUB_API_PAUSE_DURATION_AFTER_EACH_BATCH"] || "4000"
+    process.env["GITHUB_API_PAUSE_DURATION_AFTER_EACH_BATCH"] || "100"
 ) // in milliseconds
 
 console.debug(
@@ -73,7 +73,7 @@ export async function attachCurrentStarsCountsToRepositories(
 
 export async function repoStatistics(repoId: RepoId): Promise<GitHubRepoStatistics> {
     const cacheKey = `github-repo-statistics:${repoId.owner}/${repoId.repo}`
-    const cachedValue = await cacheSharedServices.get(cacheKey)
+    const cachedValue = await buildCacheBackendServices.get(cacheKey)
     if (cachedValue) {
         return cachedValue
     }
@@ -105,7 +105,7 @@ export async function repoStatistics(repoId: RepoId): Promise<GitHubRepoStatisti
         }
     }
 
-    await cacheSharedServices.set(cacheKey, result)
+    await buildCacheBackendServices.set(cacheKey, result)
 
     return result
 }

--- a/src/services/backend/projects-galleries.ts
+++ b/src/services/backend/projects-galleries.ts
@@ -11,8 +11,8 @@ import { pagesRange } from "../../helpers/pagination-helpers"
 import * as cacheSharedServices from "../shared/cache"
 import { projectGalleryCategories } from "../shared/projects-galleries"
 import * as galleryProjectsSharedServices from "../shared/projects-galleries"
+import { projectRootPath } from "./_helpers"
 
-const projectRootPath = join(new URL(import.meta.url).pathname, "..", "..", "..", "..")
 const dataFolderBasePath = join(projectRootPath, "data", "projects-galleries")
 const imagesFolderBasePath = join(projectRootPath, "public", "projects-galleries")
 

--- a/src/services/shared/cache.ts
+++ b/src/services/shared/cache.ts
@@ -7,10 +7,10 @@ type CacheKey = string
 
 const cacheStore = new Map<CacheKey, any>()
 
-let debugMode: boolean = false
+const debugMode = { miss: false, hit: false, set: false }
 
-export function enableDebugMode(): void {
-    debugMode = true
+export function enableDebugMode(debug: { miss: boolean; hit: boolean; set: boolean }): void {
+    Object.assign(debugMode, debug)
 }
 
 export async function has(key: CacheKey): Promise<boolean> {
@@ -20,14 +20,15 @@ export async function has(key: CacheKey): Promise<boolean> {
 export async function get<T = any>(key: CacheKey, defaultValue: T | null = null): Promise<T | null> {
     const value = cacheStore.get(key)
     if (value === undefined) {
-        debugMode && console.debug(`Cache: MISS for key "${key}"`)
+        debugMode.miss && console.debug(`Cache: MISS for key "${key}"`)
         return defaultValue
     }
-    debugMode && console.debug(`Cache: HIT for key "${key}"`)
+    debugMode.hit && console.debug(`Cache: HIT for key "${key}"`)
     return value
 }
 
 export async function set<T = any>(key: CacheKey, value: T): Promise<void> {
+    debugMode.set && console.debug(`Cache: saving data for key "${key}"`)
     cacheStore.set(key, value)
 }
 


### PR DESCRIPTION
It seems that Vercel will always keep the content of the `.next/cache` folder across the builds, with the following process:
> At the beginning of each Build, the previous Build's cache is restored prior to the [Install Command](https://vercel.com/docs/concepts/deployments/build-step#install-command) or [Build Command](https://vercel.com/docs/concepts/deployments/build-step#build-command) executing. This means that your first Build for a given Project might be slower because dependencies must be installed, but subsequent Builds will be faster.
> 
> When a new Git branch is created, there will not be a cache for that specific branch. Instead, the last [Production Deployment](https://vercel.com/docs/concepts/deployments/environments#production) cache will be used and a new branch cache will be created.

I realised that we can use this to also cache our own specific data between builds - like the GitHub stars count of each GitHub repository we display on this website, whether it's one of our own projects or one of the gallery!

It seems to work, as the build time is now around 30 seconds for this branch, instead of more than 2 minutes (we no longer need to fetch these stars count, with a throttling on the GH API, every time we deploy) :slightly_smiling_face: 