### PR TITLE
[backend][github] handle potential trailing slash in a repo's URL

### DIFF
--- a/src/services/backend/github.ts
+++ b/src/services/backend/github.ts
@@ -3,7 +3,7 @@ import type { RepoId } from "../../domain"
 import { humanizeStargazersCount } from "../../helpers/conversion-helpers"
 import * as buildCacheBackendServices from "../backend/build-cache"
 
-const REPO_URL_REGEX = /^https:\/\/github.com\/(?<owner>[^/]+)\/(?<repo>[^/]+)$/
+const REPO_URL_REGEX = /^https:\/\/github.com\/(?<owner>[^/]+)\/(?<repo>[^/]+)\/?$/
 const REPO_URL_PATTERN = "https://github.com/{owner}/{repo}"
 const GET_REPO_API_URL_PATTERN = "https://api.github.com/repos/{owner}/{repo}"
 


### PR DESCRIPTION
One of the recently added repos has a trailing slash in the URL specified in its Markdown file; these are valid GH repo URLs so we should handle them too :slightly_smiling_face: 