### PR TITLE
Stargazers count tiny improvements

### DIFF
--- a/data/projects.json
+++ b/data/projects.json
@@ -3,7 +3,7 @@
         {
             "id": "textual",
             "headline": "Textual",
-            "stars": "9k",
+            "stars": "10k",
             "desc": "Build amazing TUIs (Text User Interfaces) with this innovative Python framework",
             "code": "https://github.com/Textualize/textual",
             "videoUrl": "https://d32lig6y1jobn4.cloudfront.net/textual.mp4"
@@ -11,7 +11,7 @@
         {
             "id": "rich",
             "headline": "Rich",
-            "stars": "36k",
+            "stars": "37k",
             "desc": "Beautiful output in the terminal and Jupyter notebook with this powerful Python library. Tables, panels, progress bars, trees, syntax highlighting, pretty printing, and much more.",
             "code": "https://github.com/Textualize/rich",
             "docs": "https://rich.readthedocs.io/en/latest/",
@@ -20,7 +20,7 @@
         {
             "id": "rich-cli",
             "headline": "Rich CLI",
-            "stars": "1.5k",
+            "stars": "1.7k",
             "desc": "Rich from the command prompt. Syntax highlight many file-types, with special support for markdown, json, and CSV tables",
             "code": "https://github.com/Textualize/rich-cli",
             "videoUrl": "https://d32lig6y1jobn4.cloudfront.net/rich-cli.mp4"

--- a/src/services/backend/github.ts
+++ b/src/services/backend/github.ts
@@ -105,7 +105,13 @@ export async function repoStatistics(repoId: RepoId): Promise<GitHubRepoStatisti
         }
     }
 
-    await buildCacheBackendServices.set(cacheKey, result)
+    try {
+        await buildCacheBackendServices.set(cacheKey, result)
+    } catch (err) {
+        // This will happen when we refresh values after the deployment for example,
+        // as Vercel serverless functions seem to not have the `.next/cache` folder mounted.
+        console.info(`Could not save repoStatistics results for cache key "${cacheKey}": `, err)
+    }
 
     return result
 }


### PR DESCRIPTION
Fixes this error, happening when our serverless functions try to update our own projects' stars count on the fly (which happens once an hour).
![Screenshot from 2022-05-10 12-03-02](https://user-images.githubusercontent.com/722388/167615301-c7d75ccd-ca7f-459e-8e66-aa7f796435ed.png)

As I was suspecting already, it definitely seem that Vercel serverless functions do to not have the `.next/cache` folder mounted :pensive: 

While I was there I also updated the hard-coded values for these metrics :slightly_smiling_face: 