### PR TITLE
[CI] Add GitHub Actions summary when too large images are detected

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
                 "react-intersection-observer": "^8.34.0"
             },
             "devDependencies": {
+                "@actions/core": "^1.8.2",
                 "@trivago/prettier-plugin-sort-imports": "^3.2.0",
                 "@types/fscreen": "^1.0.1",
                 "@types/humanize-plus": "^1.8.0",
@@ -43,6 +44,24 @@
             },
             "engines": {
                 "node": "16.x"
+            }
+        },
+        "node_modules/@actions/core": {
+            "version": "1.8.2",
+            "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.8.2.tgz",
+            "integrity": "sha512-FXcBL7nyik8K5ODeCKlxi+vts7torOkoDAKfeh61EAkAy1HAvwn9uVzZBY0f15YcQTcZZ2/iSGBFHEuioZWfDA==",
+            "dev": true,
+            "dependencies": {
+                "@actions/http-client": "^2.0.1"
+            }
+        },
+        "node_modules/@actions/http-client": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.0.1.tgz",
+            "integrity": "sha512-PIXiMVtz6VvyaRsGY268qvj57hXQEpsYogYOu2nrQhlf+XCGmZstmuZBbAybUl1nQGnvS1k1eEsQ69ZoD7xlSw==",
+            "dev": true,
+            "dependencies": {
+                "tunnel": "^0.0.6"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -7520,6 +7539,15 @@
             "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
             "dev": true
         },
+        "node_modules/tunnel": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+            "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+            }
+        },
         "node_modules/tunnel-agent": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -8032,6 +8060,24 @@
         }
     },
     "dependencies": {
+        "@actions/core": {
+            "version": "1.8.2",
+            "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.8.2.tgz",
+            "integrity": "sha512-FXcBL7nyik8K5ODeCKlxi+vts7torOkoDAKfeh61EAkAy1HAvwn9uVzZBY0f15YcQTcZZ2/iSGBFHEuioZWfDA==",
+            "dev": true,
+            "requires": {
+                "@actions/http-client": "^2.0.1"
+            }
+        },
+        "@actions/http-client": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.0.1.tgz",
+            "integrity": "sha512-PIXiMVtz6VvyaRsGY268qvj57hXQEpsYogYOu2nrQhlf+XCGmZstmuZBbAybUl1nQGnvS1k1eEsQ69ZoD7xlSw==",
+            "dev": true,
+            "requires": {
+                "tunnel": "^0.0.6"
+            }
+        },
         "@babel/code-frame": {
             "version": "7.16.7",
             "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
@@ -13422,6 +13468,12 @@
                     "dev": true
                 }
             }
+        },
+        "tunnel": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+            "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+            "dev": true
         },
         "tunnel-agent": {
             "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
         "react-intersection-observer": "^8.34.0"
     },
     "devDependencies": {
+        "@actions/core": "^1.8.2",
         "@trivago/prettier-plugin-sort-imports": "^3.2.0",
         "@types/fscreen": "^1.0.1",
         "@types/humanize-plus": "^1.8.0",


### PR DESCRIPTION
While the CI was doing its things on my "integration tests" branch of Textual I played a bit with [the brand new GitHub Actions Summary feature](https://github.blog/2022-05-09-supercharging-github-actions-with-job-summaries/) on our Website ...
It's really cool! :star_struck: 

![Screenshot from 2022-05-17 10-59-13](https://user-images.githubusercontent.com/722388/168786290-7ca923f8-9cb0-4bd2-9e85-ca511822c7aa.png)
