### PR TITLE
change from discourse to discord

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -12,7 +12,7 @@ export const AppConfig = {
         urls: {
             twitter: "https://twitter.com/textualizeio",
             github: "https://github.com/Textualize",
-            discourse: "https://community.textualize.io/",
+            discord: "https://discord.gg/Enf6Z3qhVr",
         },
     },
 }


### PR DESCRIPTION
Per this post: https://community.textualize.io/t/community-textualize-io-to-close/172

Not sure if you want to route people to discord, directly from homepage, but at least the discourse at community.textualize.io should be removed/changed.